### PR TITLE
refactor: POST /join 기능 구현

### DIFF
--- a/src/main/java/com/example/disearch/controller/JoinController.java
+++ b/src/main/java/com/example/disearch/controller/JoinController.java
@@ -1,42 +1,49 @@
 package com.example.disearch.controller;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+
 @RestController
 public class JoinController {
+
+    @Autowired
+    private RestTemplate restTemplate;
 
     @Value("${DISCORD_BOT_TOKEN}")
     private String botToken;
 
-    private final RestTemplate restTemplate;
-
-    @Autowired
-    public JoinController(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
-    }
-
     @PostMapping("/join")
-    public String joinGuild(@RequestBody Map<String, String> request) {
-        String serverId = request.get("serverId");
-        String url = "https://discord.com/api/guilds/" + serverId + "/templates";
+    public ResponseEntity<String> joinGuild(@RequestBody Map<String, String> request) {
+        String guildId = request.get("serverId");
+        String guildsUrl = "https://discord.com/api/guilds/" + guildId;
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", botToken);
-
+        headers.set("Authorization", "Bot " + botToken);
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        ResponseEntity<String> guildResponse = restTemplate.exchange(guildsUrl, HttpMethod.GET, entity, String.class);
+        JSONObject guildResponseBody = new JSONObject(guildResponse.getBody());
+        String systemChannelId = guildResponseBody.getString("system_channel_id");
+        String invitesUrl = "https://discord.com/api/channels/" + systemChannelId + "/invites";
+        ResponseEntity<String> inviteResponse = restTemplate.exchange(invitesUrl, HttpMethod.GET, entity, String.class);
 
-        JSONObject responseBody = new JSONObject(response.getBody());
-        return responseBody.getString("code");
+        String responseString = inviteResponse.getBody();
+        JSONArray jsonArray = new JSONArray(responseString);
+        for (int i = 0; i < jsonArray.length(); i++) {
+            JSONObject jsonObject = jsonArray.getJSONObject(i);
+            if (jsonObject.has("code")) {
+                String code = jsonObject.getString("code");
+                return ResponseEntity.ok(code);
+            }
+        }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Code not found in the response");
     }
 }


### PR DESCRIPTION
기존 POST /join의 기능 최종 구현.
Discord의 API를 2단계 거침.
1. https://discord.com/api/guilds/{guild.id} - 응답: "system_channel_id": "example"
3. https://discord.com/api/channels/{channel.id}/invites - 응답: "code" : "example"